### PR TITLE
Remove deprecated APIs

### DIFF
--- a/code/testapp/src/main/java/com/adobe/mobile/marketing/userprofile/testapp/MainActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/mobile/marketing/userprofile/testapp/MainActivity.kt
@@ -157,11 +157,13 @@ fun load(sharedPreferences: SharedPreferences): Map<String, Any?> {
 }
 
 fun update(key: String, value: String) {
-    UserProfile.updateUserAttribute(key, value);
+    val attributeMap = mapOf(key to value)
+    UserProfile.updateUserAttributes(attributeMap);
 }
 
 fun remove(key: String) {
-    UserProfile.removeUserAttribute(key)
+    val attributeNames = listOf(key)
+    UserProfile.removeUserAttributes(attributeNames)
 }
 
 

--- a/code/userprofile/src/androidTest/java/com/adobe/marketing/mobile/userprofile/UserProfileIntegrationTests.java
+++ b/code/userprofile/src/androidTest/java/com/adobe/marketing/mobile/userprofile/UserProfileIntegrationTests.java
@@ -33,7 +33,6 @@ import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,58 +176,6 @@ public class UserProfileIntegrationTests {
                                 {
                                     put("k1", "value");
                                     put("k2", 2.1);
-                                    put("k4", true);
-                                }
-                            },
-                            stringObjectMap);
-                    getDataLatch.countDown();
-                });
-        getDataLatch.await();
-    }
-
-    @Test(timeout = 1000)
-    public void testUpdateUserAttribute() throws InterruptedException {
-        UserProfile.updateUserAttribute("key", "value");
-
-        final CountDownLatch getDataLatch = new CountDownLatch(1);
-        UserProfile.getUserAttributes(
-                Collections.singletonList("key"),
-                stringObjectMap -> {
-                    assertEquals(1, stringObjectMap.size());
-                    assertEquals(
-                            new HashMap<String, Object>() {
-                                {
-                                    put("key", "value");
-                                }
-                            },
-                            stringObjectMap);
-                    getDataLatch.countDown();
-                });
-        getDataLatch.await();
-    }
-
-    @Test(timeout = 1000)
-    public void testRemoveUserAttribute() throws InterruptedException {
-        UserProfile.updateUserAttributes(
-                new HashMap<String, Object>() {
-                    {
-                        put("k1", "value");
-                        put("k2", 2.1);
-                        put("k3", 3);
-                        put("k4", true);
-                    }
-                });
-        UserProfile.removeUserAttribute("k2");
-        final CountDownLatch getDataLatch = new CountDownLatch(1);
-        UserProfile.getUserAttributes(
-                Arrays.asList("k1", "k2", "k3", "k4"),
-                stringObjectMap -> {
-                    assertEquals(3, stringObjectMap.size());
-                    assertEquals(
-                            new HashMap<String, Object>() {
-                                {
-                                    put("k1", "value");
-                                    put("k3", 3);
                                     put("k4", true);
                                 }
                             },

--- a/code/userprofile/src/phone/java/com/adobe/marketing/mobile/UserProfile.java
+++ b/code/userprofile/src/phone/java/com/adobe/marketing/mobile/UserProfile.java
@@ -12,12 +12,10 @@
 package com.adobe.marketing.mobile;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.userprofile.UserProfileExtension;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,13 +24,11 @@ public class UserProfile {
     private static final String LOG_TAG = "UserProfile";
     private static final String EXTENSION_VERSION = "3.0.0";
     private static final String CLASS_NAME = "UserProfile";
-    public static final Class<? extends Extension> EXTENSION = UserProfileExtension.class;
-
     private static final String UPDATE_DATA_KEY = "userprofileupdatekey";
     private static final String GET_DATA_ATTRIBUTES = "userprofilegetattributes";
     private static final String REMOVE_DATA_KEYS = "userprofileremovekeys";
-
     private static final long API_TIMEOUT = 5000L;
+    public static final Class<? extends Extension> EXTENSION = UserProfileExtension.class;
 
     private UserProfile() {}
 
@@ -74,64 +70,6 @@ public class UserProfile {
                         .setEventData(eventDataMap)
                         .build();
         MobileCore.dispatchEvent(event);
-    }
-
-    /**
-     * UserProfile API to set user profile attributes keys and values.
-     *
-     * <p>If the attribute does not exist, it will be created. If the attribute already exists, then
-     * the value will be updated. A null attribute value will remove the attribute.
-     *
-     * <p>This API will generate a userprofile request event.
-     *
-     * @param attributeName Attribute key.
-     * @param attributeValue Attribute value corresponding to the key. Java primitive types, Maps
-     *     and Lists are supported.
-     */
-    @Deprecated
-    public static void updateUserAttribute(
-            @NonNull final String attributeName, @Nullable final Object attributeValue) {
-        if (attributeName == null || attributeName.isEmpty()) {
-            Log.debug(
-                    LOG_TAG,
-                    CLASS_NAME,
-                    "updateUserAttributes - attributeName is null or empty, no event was"
-                            + " dispatched");
-            return;
-        }
-        Log.trace(
-                LOG_TAG,
-                CLASS_NAME,
-                "Updating user attribute with attribute name: %s",
-                attributeName);
-        Map<String, Object> attributeMap = new HashMap<>();
-        attributeMap.put(attributeName, attributeValue);
-        updateUserAttributes(attributeMap);
-    }
-
-    /**
-     * UserProfile API to remove the given attribute name.
-     *
-     * <p>If the attribute does not exist, this API has no effects. If the attribute exists, then
-     * the User Attribute will be removed
-     *
-     * @param attributeName A {@link String} attribute key which has to be removed.
-     */
-    @Deprecated
-    public static void removeUserAttribute(@NonNull final String attributeName) {
-        if (attributeName == null || attributeName.isEmpty()) {
-            Log.debug(
-                    LOG_TAG,
-                    CLASS_NAME,
-                    "updateUserAttributes - attributeName is null or empty, no event was"
-                            + " dispatched");
-            return;
-        }
-        Log.trace(LOG_TAG, CLASS_NAME, "Removing user attribute with key: %s", attributeName);
-
-        List<String> keys = new ArrayList<>(1);
-        keys.add(attributeName);
-        removeUserAttributes(keys);
     }
 
     /**

--- a/code/userprofile/src/test/java/com/adobe/marketing/mobile/PublicAPITests.java
+++ b/code/userprofile/src/test/java/com/adobe/marketing/mobile/PublicAPITests.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 
 import com.adobe.marketing.mobile.userprofile.UserProfileExtension;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,70 +74,6 @@ public class PublicAPITests {
                 Mockito.mockStatic(MobileCore.class)) {
             mobileCoreMockedStatic.reset();
             UserProfile.updateUserAttributes(null);
-            mobileCoreMockedStatic.verifyNoInteractions();
-        }
-    }
-
-    @Test
-    public void test_updateUserAttribute() {
-        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
-                Mockito.mockStatic(MobileCore.class)) {
-            mobileCoreMockedStatic.reset();
-            ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-            UserProfile.updateUserAttribute("key", "value");
-            mobileCoreMockedStatic.verify(() -> MobileCore.dispatchEvent(eventCaptor.capture()));
-            Event dispatchedEvent = eventCaptor.getValue();
-            assertNotNull(dispatchedEvent);
-            assertEquals("UserProfileUpdate", dispatchedEvent.getName());
-            assertEquals("com.adobe.eventType.userProfile", dispatchedEvent.getType());
-            assertEquals("com.adobe.eventSource.requestProfile", dispatchedEvent.getSource());
-            Map<String, Object> eventData = dispatchedEvent.getEventData();
-            assertTrue(eventData.containsKey("userprofileupdatekey"));
-            assertEquals(
-                    new HashMap<String, Object>() {
-                        {
-                            put("key", "value");
-                        }
-                    },
-                    eventData.get("userprofileupdatekey"));
-        }
-    }
-
-    @Test
-    public void test_updateUserAttribute_withNullKey() {
-        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
-                Mockito.mockStatic(MobileCore.class)) {
-            mobileCoreMockedStatic.reset();
-            UserProfile.updateUserAttribute(null, null);
-            mobileCoreMockedStatic.verifyNoInteractions();
-        }
-    }
-
-    @Test
-    public void test_removeUserAttribute() {
-        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
-                Mockito.mockStatic(MobileCore.class)) {
-            mobileCoreMockedStatic.reset();
-            ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-            UserProfile.removeUserAttribute("key");
-            mobileCoreMockedStatic.verify(() -> MobileCore.dispatchEvent(eventCaptor.capture()));
-            Event dispatchedEvent = eventCaptor.getValue();
-            assertNotNull(dispatchedEvent);
-            assertEquals("RemoveUserProfile", dispatchedEvent.getName());
-            assertEquals("com.adobe.eventType.userProfile", dispatchedEvent.getType());
-            assertEquals("com.adobe.eventSource.requestReset", dispatchedEvent.getSource());
-            Map<String, Object> eventData = dispatchedEvent.getEventData();
-            assertTrue(eventData.containsKey("userprofileremovekeys"));
-            assertEquals(Collections.singletonList("key"), eventData.get("userprofileremovekeys"));
-        }
-    }
-
-    @Test
-    public void test_removeUserAttribute_withNullKey() {
-        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
-                Mockito.mockStatic(MobileCore.class)) {
-            mobileCoreMockedStatic.reset();
-            UserProfile.removeUserAttribute(null);
             mobileCoreMockedStatic.verifyNoInteractions();
         }
     }


### PR DESCRIPTION
Remove following APIs which were deprecated with 2.x 

UserProfile.updateUserAttribute
```
public static void updateUserAttribute(@NonNull final String attributeName, @Nullable final Object attributeValue) 
in favor of
public static void updateUserAttributes(@NonNull final Map<String, Object> attributeMap) 
```

UserProfile.removeUserAttribute
```
public static void removeUserAttribute(@NonNull final String attributeName)
in favor of 
public static void removeUserAttributes(@NonNull final List<String> attributeNames) {
```