### PR TITLE
Migrate to CentralSonatype publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-and-test:
     name: "CI"
-    uses: adobe/aepsdk-commons/.github/workflows/android-build-and-test.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-build-and-test.yml@gha-android-3.4.2
     with:
       android-api-levels: '[29]'
       run-test-unit: true
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
   build-test-app:
     name: "CI"
-    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-custom-command-build-and-test.yml@gha-android-3.4.2
     with:
       android-api-levels: '[29]'
       command: make ci-publish-maven-local-jitpack && make assemble-app

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -35,10 +35,11 @@ jobs:
   publish:
     permissions:
         contents: write
-    uses: adobe/aepsdk-commons/.github/workflows/android-maven-release.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-maven-release.yml@gha-android-3.4.2
     with:
       tag: ${{ github.event.inputs.tag }}
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' }}
       version-validation-paths: code/gradle.properties, code/userprofile/src/phone/java/com/adobe/marketing/mobile/UserProfile.java
       version-validation-dependencies: Core ${{ github.event.inputs.core-dependency }}
+      staging-dir: code/userprofile/build/staging
     secrets: inherit

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -41,5 +41,5 @@ jobs:
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' }}
       version-validation-paths: code/gradle.properties, code/userprofile/src/phone/java/com/adobe/marketing/mobile/UserProfile.java
       version-validation-dependencies: Core ${{ github.event.inputs.core-dependency }}
-      staging-dir: code/userprofile/build/staging
+      staging-dir: code/userprofile/build/staging-deploy
     secrets: inherit

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -14,10 +14,18 @@ name: Publish Snapshot
 
 on: 
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git reference (branch, tag, or SHA) to check out when publishing the snapshot. Defaults to 'staging'."
+        required: false
+        default: 'staging'
 
 jobs:
   publish:
     permissions:
         contents: write
-    uses: adobe/aepsdk-commons/.github/workflows/android-maven-snapshot.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-maven-snapshot.yml@gha-android-3.4.2
     secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      staging-dir: code/userprofile/build/staging

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -28,4 +28,4 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
-      staging-dir: code/userprofile/build/staging
+      staging-dir: code/userprofile/build/staging-deploy

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.4.2
     with:
       version: ${{ github.event.inputs.version }}
       branch: ${{ github.event.inputs.branch }}

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ assemble-app:
 		(./code/gradlew -p code/testapp  assemble)
 
 ci-publish-maven-local-jitpack: assemble-phone-release
-		(./code/gradlew -p code/userprofile publishReleasePublicationToMavenLocal -Pjitpack  -x signReleasePublication)
+		(./code/gradlew -p code/userprofile publishReleasePublicationToMavenLocal -Pjitpack)
 
-ci-publish-staging: assemble-phone-release
-		(./code/gradlew -p code/userprofile publishReleasePublicationToSonatypeRepository)
+ci-publish-staging: clean
+		(./code/gradlew -p code/userprofile publish)
 
-ci-publish: assemble-phone-release
-		(./code/gradlew -p code/userprofile  publishReleasePublicationToSonatypeRepository -Prelease)
+ci-publish: clean
+		(./code/gradlew -p code/userprofile  publish -Prelease)

--- a/code/build.gradle.kts
+++ b/code/build.gradle.kts
@@ -7,6 +7,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath("com.github.adobe:aepsdk-commons:gp-3.0.0")
+        classpath("com.github.adobe:aepsdk-commons:gp-3.4.0")
     }
 }

--- a/code/settings.gradle.kts
+++ b/code/settings.gradle.kts
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         mavenLocal()
-        maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
         maven { url = uri("https://jitpack.io") }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
OSS Sonatype publishing is being deprecated in favor of Central Sonatype. `aepsdk-commons` was updated with the latest changes required for this changes. This PR has necessary changes to adopt the migration changes.

**Workflows**:
 - Update workflows to use gha-android-3.4.2
 - Set the staging-dir to match the build artifact directories for individual extensions
 - Utilize branch ref option to direct snapshots branches

**Gradle**:
 - Update to use AEP SDK Gradle Plugin 3.4.0
 - Fetch from central sonatype snapshots instead of OSS.

**Makefile**:
 - Switch the ci-publish-main and ci-publish-snapshot to trigger the publish command instead.

<!--- Describe your changes in detail -->
